### PR TITLE
Improved integration with the OS

### DIFF
--- a/Drive/AppDelegate.swift
+++ b/Drive/AppDelegate.swift
@@ -31,8 +31,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         
         loadRecentsMenu()
     }
+    
+    func application(_ application: NSApplication, open urls: [URL]) {
+        
+        urls.forEach { (url) in
+            if (url.absoluteString.starts(with: "https://drive.google.com")) {
+                // Open Drive links in the main window
+                window.makeKeyAndOrderFront(nil)
+                
+                let viewController = NSApplication.shared.mainWindow?.contentViewController as! ViewController
+                let request = URLRequest(url: url)
+                
+                viewController.loadRequest(request: request)
+            } else {
+                // Open document links in a new window
+                openWindow(url: url)
+            }
+        }
+    }
 
     @IBAction func handleOpen(_ sender: Any) {
+        
         window.makeKeyAndOrderFront(nil)
     }
     
@@ -73,16 +92,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     @IBAction func handleNewDoc(_ sender: Any) {
+        
         let url = URL(string: "https://docs.google.com/document/create?hl=en")
         openWindow(url: url!)
     }
     
     @IBAction func handleNewSlide(_ sender: Any) {
+        
         let url = URL(string: "https://docs.google.com/presentation/create?hl=en")
         openWindow(url: url!)
     }
     
     @IBAction func handleNewSheet(_ sender: Any) {
+        
         let url = URL(string: "https://docs.google.com/spreadsheets/create?hl=en")
         openWindow(url: url!)
     }
@@ -95,6 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     func openWindow(url: URL) {
+        
         let request = URLRequest(url: url)
         
         let viewController = ViewController()
@@ -110,6 +133,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     func applicationWillBecomeActive(_ notification: Notification) {
+        
         let windowCount = NSApplication.shared.windows.count
         if windowCount == 1 && !window.isVisible {
             window.makeKeyAndOrderFront(nil)
@@ -120,6 +144,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     func loadRecentsMenu() {
+        
         openRecentMenu.removeAllItems()
         
         guard let recents = UserDefaults.standard.value(forKey: "kRecentDocuments") as? [[String:String]] else {

--- a/Drive/AppDelegate.swift
+++ b/Drive/AppDelegate.swift
@@ -59,6 +59,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         })
     }
     
+    @IBAction func handleCopyLink(_ sender: Any) {
+        
+        // Get URL of frontmost window and copy to clipboard
+        let viewController = NSApplication.shared.keyWindow?.contentViewController as! ViewController
+        let url = viewController.webView.mainFrameURL
+        
+        if (url != nil) {
+            let pasteboard = NSPasteboard.general
+            pasteboard.declareTypes([NSPasteboard.PasteboardType.string], owner: nil)
+            pasteboard.setString(url!, forType: NSPasteboard.PasteboardType.string)
+        }
+    }
+    
     @IBAction func handleNewDoc(_ sender: Any) {
         let url = URL(string: "https://docs.google.com/document/create?hl=en")
         openWindow(url: url!)

--- a/Drive/Base.lproj/MainMenu.xib
+++ b/Drive/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -372,6 +372,13 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
                         <items>
+                            <menuItem title="Copy Link" keyEquivalent="l" id="lfm-C3-Ztc">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="handleCopyLink:" target="-1" id="IZq-XC-FG3"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="SKg-I4-oHH"/>
                             <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
                                 <connections>
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>

--- a/Drive/Info.plist
+++ b/Drive/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.3</string>
 	<key>CFBundleVersion</key>
-	<string>1.3.1</string>
+	<string>1.3.3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
As referenced in #9, I'm using [Choosy](https://www.choosyosx.com) to intercept URLs at the OS level matching drive.google.com and docs.google.com, using Drive.app as my default 'browser' for those rules.

I've added two commits to aid that workflow:

1. Allows Drive.app to receive URLs from the OS, and open them in the main window (for drive.google.com) and new windows (for docs.google.com) as appropriate
2. Adds a "Copy Link" command for the frontmost window, allowing easy URL sharing with collaborators which is hidden right now, as the app doesn't (and shouldn't!) display a URL bar

This closes #9 and #10 (if the author of the latter issue wishes to utilise Choosy, too)